### PR TITLE
[FEATURE] V1.0.5 Set wp_remote_post method as default to POST data to…

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ If you haven't already, [generate your API keys first](https://www.google.com/re
 
 ### Installation and Usage
 
-This plugin requires cURL to be enabled on your server, as it makes use of Google's [PHP library](https://github.com/google/recaptcha).
+This plugin does not require CuRL to be enabled on your server
 
 1. Copy the `acf-recaptcha` folder into your `wp-content/plugins` folder
 2. Activate the plugin via the plugins admin page
@@ -46,8 +46,9 @@ acf_add_local_field(array(
 
 ## About
 
-Version 1.0.4
+Version 1.0.5
 
 Written by Irvin Lim. If you encounter any issues, do open [one](https://github.com/irvinlim/acf-recaptcha/issues/new).
+WordPress wp_remote_post usage in WP Class written by Ramon Fincken (v 1.0.5)
 
 If you have any other questions, contact me [here](http://services.irvinlim.com/contact.php)!

--- a/acf-recaptcha-v5.php
+++ b/acf-recaptcha-v5.php
@@ -58,7 +58,7 @@ class acf_field_recaptcha extends acf_field {
 		);
 				
 		// do not delete!
-    	parent::__construct();
+    		parent::__construct();
     	
 	}
 	
@@ -238,7 +238,7 @@ class acf_field_recaptcha extends acf_field {
 		if (!strlen($value)) 
 			return false;
 
-		$api = new \ReCaptcha\ReCaptcha($field['secret_key']);
+		$api = new \ReCaptcha\ReCaptcha($field['secret_key']); // FIXME : select field for request method?
 		$response = $api->verify($value, $_SERVER['REMOTE_ADDR']);
 	  
 	  if ( $response->isSuccess() ) 

--- a/acf-recaptcha.php
+++ b/acf-recaptcha.php
@@ -4,7 +4,7 @@
 Plugin Name: Advanced Custom Fields: reCAPTCHA Field
 Plugin URI: https://github.com/irvinlim/acf-recaptcha/
 Description: Google reCAPTCHA Field for Advanced Custom Fields. See <a href="https://www.google.com/recaptcha/">https://www.google.com/recaptcha/</a> for an account.
-Version: 1.0.4
+Version: 1.0.5
 Author: Irvin Lim
 Author URI: http://irvinlim.com
 License: GPLv2 or later

--- a/lib/ReCaptcha/ReCaptcha.php
+++ b/lib/ReCaptcha/ReCaptcha.php
@@ -70,7 +70,7 @@ class ReCaptcha
         if (!is_null($requestMethod)) {
             $this->requestMethod = $requestMethod;
         } else {
-            $this->requestMethod = new RequestMethod\Post();
+            $this->requestMethod = new RequestMethod\WP();
         }
     }
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: acf, field, recaptcha, captcha, form, frontend
 Donate link: https://irvinlim.com/contact?subject=Donations
 Requires at least: 3.0.1
 Tested up to: 4.6.1
-Stable tag: 1.0.4
+Stable tag: 1.0.5
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -15,7 +15,7 @@ This is an add-on for the [Advanced Custom Fields](http://wordpress.org/extend/p
 
 You can find more information on Google's No-CAPTCHA reCAPTCHA [here](https://www.google.com/recaptcha/intro/index.html).
 
-Requires cURL to be enabled on your server.
+This plugin does not require CuRL to be enabled on your server.
 
 = Compatibility =
 
@@ -39,6 +39,9 @@ That's it! It should work out of the box, as long as your API keys are correct a
 1. Frontend look
 
 == Changelog ==
+= 1.0.5 =
+* Set wp_remote_post method as default to POST data to google recaptcha. This removes the need for CuRL on your server as WP will select the appropriate method. Props ramonfincken
+
 = 1.0.4 =
 * Fix WSOD errors
 


### PR DESCRIPTION
This removes the need for CuRL on your server as WP will select the appropriate method. Props ramonfincken