### PR TITLE
Fix enqueue script locations

### DIFF
--- a/acf-recaptcha-v5.php
+++ b/acf-recaptcha-v5.php
@@ -191,15 +191,22 @@ class acf_field_recaptcha extends acf_field {
 
         $dir = plugin_dir_url(__FILE__);
         wp_register_script('acf-input-recaptcha', "{$dir}js/input.js", array( "acf-input" ));
+        wp_register_script('recaptcha-field-group', "{$dir}js/field-group.js", array( "acf-field-group" ));
+        
         wp_enqueue_script('acf-input-recaptcha');
 
         if (!is_admin()) {
             wp_enqueue_script('recaptcha-api', 'https://www.google.com/recaptcha/api.js');
         }
 
-        // Enqueue 'field-group' script only when editing field group.
+        // Enqueue 'field-group' script when editing field group.
         if (is_admin()) {
-            wp_enqueue_script('recaptcha-field-group', "{$dir}js/field-group.js", array( "acf-field-group" ));
+            $screen = get_current_screen();
+
+            // Only enqueue script for 'edit' and 'post-new' when `post-type` is 'acf-field-group'.
+            if ($screen->post_type == 'acf-field-group') {
+                wp_enqueue_script('recaptcha-field-group');
+            }
         }
 
     }

--- a/acf-recaptcha-v5.php
+++ b/acf-recaptcha-v5.php
@@ -192,14 +192,17 @@ class acf_field_recaptcha extends acf_field {
         $dir = plugin_dir_url(__FILE__);
         wp_register_script('acf-input-recaptcha', "{$dir}js/input.js", array( "acf-input" ));
         wp_register_script('recaptcha-field-group', "{$dir}js/field-group.js", array( "acf-field-group" ));
-        
-        wp_enqueue_script('acf-input-recaptcha');
 
+        // Enqueue frontend scripts for acf-recaptcha field.
         if (!is_admin()) {
+            // Enqueue input script for frontend acf-recaptcha field validation and conditional logic.
+            wp_enqueue_script('acf-input-recaptcha');
+
+            // Enqueue Google's reCAPTCHA API script in the frontend.
             wp_enqueue_script('recaptcha-api', 'https://www.google.com/recaptcha/api.js');
         }
 
-        // Enqueue 'field-group' script when editing field group.
+        // Enqueue 'field-group' script for editing field group.
         if (is_admin()) {
             $screen = get_current_screen();
 


### PR DESCRIPTION
Fixes #18. 

`input.js` will only be enqueued in the frontend, and `field-group.js` will only be enqueued when editing/adding a field group, which is at either `/wp-admin/post.php?post=<FIELD_GROUP_ID>&action=edit`, or `/wp-admin/post-new.php?post_type=acf-field-group`.