### PR TITLE
v1.2.1

### DIFF
--- a/acf-recaptcha-v5.php
+++ b/acf-recaptcha-v5.php
@@ -386,7 +386,7 @@ class acf_field_recaptcha extends acf_field {
          *   - `acf_register_form($args)`
          */
 
-        if (isset($form['recaptcha']) && $form['recaptcha'] === true) {
+        if (isset($form['recaptcha']) && ($form['recaptcha'] === true || $form['recaptcha'] === 'true')) {
             return true;
         }
 

--- a/acf-recaptcha-v5.php
+++ b/acf-recaptcha-v5.php
@@ -237,8 +237,11 @@ class acf_field_recaptcha extends acf_field {
         // Determine if the form has the 'recaptcha' flag.
         $form_requires_recaptcha = $this->check_if_form_requires_recaptcha($form);
 
-        // Don't handle forms without the flag set.
-        if (!$form_requires_recaptcha) {
+        // Determine if the form contains any 'recaptcha' field types.
+        $form_contains_recaptcha = $this->check_if_form_has_recaptcha_field($form);
+
+        // Don't handle forms without the flag or any recaptcha fields.
+        if (!$form_requires_recaptcha && !$form_contains_recaptcha) {
             return;
         }
 
@@ -323,6 +326,24 @@ class acf_field_recaptcha extends acf_field {
     }
 
     /**
+     * Checks if any fields from $_POST is a recaptcha field type.
+     *
+     * @date    01/11/2017
+     * @since   1.2.1
+     */
+    function check_if_form_has_recaptcha_field() {
+        foreach ($_POST['acf'] as $field_key => $value) {
+            $field = acf_get_field($field_key);
+
+            if ($field['type'] === 'recaptcha') {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * Unsets all recaptcha fields from $_POST data prior to saving the form.
      *
      * @date    08/07/2017
@@ -332,7 +353,7 @@ class acf_field_recaptcha extends acf_field {
         foreach ($_POST['acf'] as $field_key => $value) {
             $field = acf_get_field($field_key);
 
-            if ($field['type'] == 'recaptcha') {
+            if ($field['type'] === 'recaptcha') {
                 unset($_POST['acf'][$field_key]);
             }
         }

--- a/acf-recaptcha.php
+++ b/acf-recaptcha.php
@@ -4,7 +4,7 @@
 Plugin Name: Advanced Custom Fields: reCAPTCHA Field
 Plugin URI: https://github.com/irvinlim/acf-recaptcha/
 Description: Google reCAPTCHA Field for Advanced Custom Fields. See <a href="https://www.google.com/recaptcha/">https://www.google.com/recaptcha/</a> for an account.
-Version: 1.2.0
+Version: 1.2.1
 Author: Irvin Lim
 Author URI: https://irvinlim.com
 License: MIT

--- a/includes/classes/WPRemoteRequestMethod.php
+++ b/includes/classes/WPRemoteRequestMethod.php
@@ -27,11 +27,11 @@ class WPRemoteRequestMethod implements RequestMethod {
             'body' => $params->toQueryString(),
         ));
 
-        if (!is_wp_error($response)) {
-            return wp_remote_retrieve_body($response);
+        // Show WP error page if the request was not made successfully.
+        if (is_wp_error($response)) {
+            wp_die('<strong>ACF reCAPTCHA validation error:</strong><br />' . $response->get_error_message());
         }
 
-        // Alltough we try to decode json we will throw the error
-        throw $response->get_error_message();
+        return wp_remote_retrieve_body($response);
     }
 }

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: irvinlim
 Tags: acf, field, recaptcha, captcha, form, frontend
 Donate link: https://irvinlim.com/contact/
 Requires at least: 3.0.1
-Tested up to: 4.8
-Stable tag: 1.2.0
+Tested up to: 4.8.0
+Stable tag: 1.2.1
 License: MIT
 License URI: https://github.com/irvinlim/acf-recaptcha/blob/master/LICENSE
 
@@ -52,6 +52,11 @@ In order to use ACF reCAPTCHA, you need to generate your reCAPTCHA API keys for 
 3. Example frontend form with ACF reCAPTCHA used with Conditional Logic. The textarea is only displayed when the reCAPTCHA is solved.
 
 == Changelog ==
+= 1.2.1 =
+* Better handling of server-side reCAPTCHA verification errors
+* Accepted 'true' as a string value when using acf_form() to set the flag directly
+* Perform server-side verification of recaptcha fields in form even if recaptcha flag is not set (to catch misconfigurations)
+
 = 1.2.0 =
 * Fixed an important security bug, which allowed bots to bypass reCAPTCHA. Read more [here](https://github.com/irvinlim/acf-recaptcha/pull/22)
 * Multiple reCAPTCHA widgets will be able to render on the same page


### PR DESCRIPTION
Just some minor patches.

## What's new

* Better handling of server-side reCAPTCHA verification errors
* Accepted `'true'` as a string value when using `acf_form()` to set the flag directly
* Perform server-side verification of `recaptcha` fields in form even if `recaptcha` flag is not set (to catch misconfigurations)
