### PR TITLE
ReCAPTCHA Keys from Options

### DIFF
--- a/acf-recaptcha-v5.php
+++ b/acf-recaptcha-v5.php
@@ -38,7 +38,7 @@ class acf_field_recaptcha extends acf_field {
             're_theme' => 'light',
             're_type' => 'image',
             're_size' => 'normal',
-        );;
+        );
 
         // Adds a filter to validate forms with reCAPTCHA protection switched on.
         add_filter('acf/validate_save_post', array($this, 'validate_save_recaptcha_post'), 10, 0);

--- a/acf-recaptcha-v5.php
+++ b/acf-recaptcha-v5.php
@@ -73,16 +73,16 @@ class acf_field_recaptcha extends acf_field {
             'label' => __('Site Key', 'acf-recaptcha'),
             'instructions' => __('Enter your site key from Google reCAPTCHA.', 'acf-recaptcha'),
             'name' => 'site_key',
-            'placeholder' => $this->settings['site_key'],
-            'required' => false,
+            'placeholder' => ($this->settings['site_key']) ? __('Leave blank to use default keys', 'acf-recaptcha'): '',
+            'required' => ($this->settings['site_key']) ? false : true,
         ));
 
         acf_render_field_setting($field, array(
             'label' => __('Secret Key', 'acf-recaptcha'),
             'instructions' => __('Enter your secret key from Google reCAPTCHA.', 'acf-recaptcha'),
             'name' => 'secret_key',
-            'placeholder' => $this->settings['site_key'],
-            'required' => false,
+            'placeholder' => ($this->settings['secret_key']) ? __('Leave blank to use default keys', 'acf-recaptcha'): '',
+            'required' => ($this->settings['secret_key']) ? false : true,
         ));
 
         acf_render_field_setting($field, array(

--- a/acf-recaptcha-v5.php
+++ b/acf-recaptcha-v5.php
@@ -70,6 +70,22 @@ class acf_field_recaptcha extends acf_field {
         ));
 
         acf_render_field_setting($field, array(
+            'label' => __('Site Key', 'acf-recaptcha'),
+            'instructions' => __('Enter your site key from Google reCAPTCHA.', 'acf-recaptcha'),
+            'name' => 'site_key',
+            'placeholder' => $this->settings['site_key'],
+            'required' => false,
+        ));
+
+        acf_render_field_setting($field, array(
+            'label' => __('Secret Key', 'acf-recaptcha'),
+            'instructions' => __('Enter your secret key from Google reCAPTCHA.', 'acf-recaptcha'),
+            'name' => 'secret_key',
+            'placeholder' => $this->settings['site_key'],
+            'required' => false,
+        ));
+
+        acf_render_field_setting($field, array(
             'label' => __('Theme', 'acf-recaptcha'),
             'type' => 'radio',
             'name' => 're_theme',
@@ -410,6 +426,7 @@ class acf_field_recaptcha extends acf_field {
          */
 
         if (!empty($form['field_groups'])) {
+            da($field_groups);
             foreach ($form['field_groups'] as $group_name) {
                 $group = acf_get_field_group($group_name);
 

--- a/acf-recaptcha-v5.php
+++ b/acf-recaptcha-v5.php
@@ -7,8 +7,13 @@ require("lib/autoload.php");
 require('includes/classes/WPRemoteRequestMethod.php');
 
 class acf_field_recaptcha extends acf_field {
+    public $settings = array();
 
     function __construct() {
+        $settings = get_option('acf_recaptcha');
+        $this->settings['site_key'] = $settings['site_key'];
+        $this->settings['secret_key'] = $settings['secret_key'];
+
 
         /**
          * Unique identifier for the field type.
@@ -28,13 +33,12 @@ class acf_field_recaptcha extends acf_field {
         /**
          * Array of default settings which are merged into the field object.
          */
+
         $this->defaults = array(
-            'site_key' => '',
-            'secret_key' => '',
             're_theme' => 'light',
             're_type' => 'image',
             're_size' => 'normal',
-        );
+        );;
 
         // Adds a filter to validate forms with reCAPTCHA protection switched on.
         add_filter('acf/validate_save_post', array($this, 'validate_save_recaptcha_post'), 10, 0);
@@ -63,20 +67,6 @@ class acf_field_recaptcha extends acf_field {
             'message' => render_field_message(),
             'type' => 'message',
             'new_lines' => false
-        ));
-
-        acf_render_field_setting($field, array(
-            'label' => __('Site Key', 'acf-recaptcha'),
-            'instructions' => __('Enter your site key from Google reCAPTCHA.', 'acf-recaptcha'),
-            'name' => 'site_key',
-            'required' => true,
-        ));
-
-        acf_render_field_setting($field, array(
-            'label' => __('Secret Key', 'acf-recaptcha'),
-            'instructions' => __('Enter your secret key from Google reCAPTCHA.', 'acf-recaptcha'),
-            'name' => 'secret_key',
-            'required' => true,
         ));
 
         acf_render_field_setting($field, array(
@@ -111,7 +101,6 @@ class acf_field_recaptcha extends acf_field {
                 'compact' => __('compact'),
             ),
         ));
-
     }
 
     /**
@@ -128,8 +117,8 @@ class acf_field_recaptcha extends acf_field {
             return;
         }
 
-        if ($field['site_key'] && $field['secret_key']): ?>
-            <div class="g-recaptcha" data-sitekey="<?php echo $field['site_key']; ?>"
+        if ($this->settings['site_key'] && $this->settings['secret_key']): ?>
+            <div class="g-recaptcha" data-sitekey="<?php echo $this->settings['site_key']; ?>"
                  data-theme="<?php echo $field['re_theme']; ?>" data-type="<?php echo $field['re_type']; ?>"
                  data-size="<?php echo $field['re_size']; ?>"></div>
             <input type="hidden" name="<?php echo $field['name'] ?>">
@@ -374,7 +363,7 @@ class acf_field_recaptcha extends acf_field {
      */
     function validate_recaptcha_value($field, $value) {
         // Prepare the API.
-        $api = new \ReCaptcha\ReCaptcha($field['secret_key'], new \ReCaptcha\RequestMethod\WPRemoteRequestMethod());
+        $api = new \ReCaptcha\ReCaptcha($this->settings['secret_key'], new \ReCaptcha\RequestMethod\WPRemoteRequestMethod());
 
         // Verify the value, with the IP address of the visitor (if server is not behind a proxy).
         $response = $api->verify($value, $_SERVER['REMOTE_ADDR']);
@@ -410,6 +399,8 @@ class acf_field_recaptcha extends acf_field {
         if (isset($form['recaptcha']) && ($form['recaptcha'] === true || $form['recaptcha'] === 'true')) {
             return true;
         }
+
+
 
         /*
          * If not, determine if any of the field groups has the 'recaptcha' flag set.

--- a/acf-recaptcha.php
+++ b/acf-recaptcha.php
@@ -24,6 +24,7 @@ load_plugin_textdomain('acf-recaptcha', false, dirname(plugin_basename(__FILE__)
 /**
  * Loads any auxiliary files.
  */
+include_once('includes/settings-page.php');
 include_once('includes/plugin-update.php');
 include_once('includes/script-loader.php');
 include_once('includes/field-message.php');

--- a/includes/settings-page
+++ b/includes/settings-page
@@ -1,0 +1,74 @@
+<?php
+add_action('admin_menu', 'acf_recaptcha_add_admin_menu');
+add_action('admin_init', 'acf_recaptcha_settings_init');
+
+
+function acf_recaptcha_add_admin_menu()
+{
+    add_options_page(__('ACF ReCaptcha', 'acf-recaptcha'), __('ACF ReCaptcha', 'acf-recaptcha'), 'manage_options', 'acf_recaptcha', 'acf_recaptcha_options_page');
+}
+
+
+function acf_recaptcha_settings_init()
+{
+    register_setting('acf_recaptcha_settings', 'acf_recaptcha');
+
+    add_settings_section(
+        'acf_recaptcha_settings_section',
+        __('ReCaptcha Keys', 'acf-recaptcha'),
+        'acf_recaptcha_settings_section_callback',
+        'acf_recaptcha_settings'
+    );
+
+    add_settings_field(
+        'site_key',
+        __('Enter your site key from Google reCAPTCHA.', 'acf-recaptcha'),
+        'site_key_render',
+        'acf_recaptcha_settings',
+        'acf_recaptcha_settings_section'
+    );
+
+    add_settings_field(
+        'secret_key',
+        __('Enter your secret key from Google reCAPTCHA.', 'acf-recaptcha'),
+        'secret_key_render',
+        'acf_recaptcha_settings',
+        'acf_recaptcha_settings_section'
+    );
+
+
+}
+
+
+function site_key_render()
+{
+    $options = get_option('acf_recaptcha');
+    echo '<input type="text" name="acf_recaptcha[site_key]" value="'.$options['site_key'].'">';
+}
+
+
+function secret_key_render()
+{
+    $options = get_option('acf_recaptcha');
+    echo '<input type="text" name="acf_recaptcha[secret_key]" value="'.$options['secret_key'].'">';
+}
+
+
+function acf_recaptcha_settings_section_callback()
+{
+    $link = '<a href="https://www.google.com/recaptcha/admin" target="_blank">Google reCAPTCHA Dashboard</a>';
+    printf(__('Go to the %s to generate your Site Key and Secret Key, then enter them here.', 'acf-recaptcha'), $link);
+}
+
+
+function acf_recaptcha_options_page()
+{
+    echo '
+    <form action="options.php" method="post">
+        <h1>'.__('ACF ReCaptcha Settings', 'acf-recaptcha').'</h1>';
+    settings_fields('acf_recaptcha_settings');
+    do_settings_sections('acf_recaptcha_settings');
+    submit_button();
+    echo '
+    </form>';
+}

--- a/includes/settings-page
+++ b/includes/settings-page
@@ -72,3 +72,13 @@ function acf_recaptcha_options_page()
     echo '
     </form>';
 }
+
+
+function acf_recaptcha_add_settings_link($links)
+{
+    $settings_link = '<a href="options-general.php?page=acf-recaptcha">'.__('Settings', 'acf-recaptcha').'</a>';
+    array_push($links, $settings_link);
+    return $links;
+}
+add_filter("plugin_action_links_advanced-custom-fields-recaptcha-field/acf-recaptcha.php", "acf_recaptcha_add_settings_link");
+

--- a/includes/settings-page.php
+++ b/includes/settings-page.php
@@ -5,17 +5,17 @@ add_action('admin_init', 'acf_recaptcha_settings_init');
 
 function acf_recaptcha_add_admin_menu()
 {
-    add_options_page(__('ACF ReCaptcha', 'acf-recaptcha'), __('ACF ReCaptcha', 'acf-recaptcha'), 'manage_options', 'acf_recaptcha', 'acf_recaptcha_options_page');
+    add_options_page(__('ACF reCAPTCHA', 'acf-recaptcha'), __('ACF reCAPTCHA', 'acf-recaptcha'), 'manage_options', 'acf-recaptcha', 'acf_recaptcha_options_page');
 }
 
 
 function acf_recaptcha_settings_init()
 {
-    register_setting('acf_recaptcha_settings', 'acf_recaptcha');
+    register_setting('acf_recaptcha_settings', 'acf-recaptcha');
 
     add_settings_section(
         'acf_recaptcha_settings_section',
-        __('ReCaptcha Keys', 'acf-recaptcha'),
+        __('reCAPTCHA Keys', 'acf-recaptcha'),
         'acf_recaptcha_settings_section_callback',
         'acf_recaptcha_settings'
     );
@@ -81,4 +81,3 @@ function acf_recaptcha_add_settings_link($links)
     return $links;
 }
 add_filter("plugin_action_links_advanced-custom-fields-recaptcha-field/acf-recaptcha.php", "acf_recaptcha_add_settings_link");
-

--- a/includes/settings-page.php
+++ b/includes/settings-page.php
@@ -5,13 +5,13 @@ add_action('admin_init', 'acf_recaptcha_settings_init');
 
 function acf_recaptcha_add_admin_menu()
 {
-    add_options_page(__('ACF reCAPTCHA', 'acf-recaptcha'), __('ACF reCAPTCHA', 'acf-recaptcha'), 'manage_options', 'acf-recaptcha', 'acf_recaptcha_options_page');
+    add_options_page(__('ACF reCAPTCHA', 'acf-recaptcha'), __('ACF reCAPTCHA', 'acf-recaptcha'), 'manage_options', 'acf_recaptcha', 'acf_recaptcha_options_page');
 }
 
 
 function acf_recaptcha_settings_init()
 {
-    register_setting('acf_recaptcha_settings', 'acf-recaptcha');
+    register_setting('acf_recaptcha_settings', 'acf_recaptcha');
 
     add_settings_section(
         'acf_recaptcha_settings_section',


### PR DESCRIPTION
Adds a settings page to the plugin, where recaptcha keys can be stored and accessed as opposed to needing to define them each time we add a recaptcha field.