### PR TITLE
Disable functionality on ACF v4

### DIFF
--- a/acf-recaptcha.php
+++ b/acf-recaptcha.php
@@ -22,18 +22,21 @@ load_plugin_textdomain('acf-recaptcha', false, dirname(plugin_basename(__FILE__)
 
 
 /**
- * Loads any auxiliary files.
- */
-include_once('includes/settings-page.php');
-include_once('includes/plugin-update.php');
-include_once('includes/script-loader.php');
-include_once('includes/field-message.php');
-
-
-/**
- * Loads the acf_field classes.
+ * Loads the field type.
  */
 function include_field_types_recaptcha($version) {
+    // Only support version 5.
+    if ($version !== 5) {
+        return;
+    }
+
+    // Load auxilliary classes
+    include_once('includes/settings-page.php');
+    include_once('includes/plugin-update.php');
+    include_once('includes/script-loader.php');
+    include_once('includes/field-message.php');
+
+    // Loads the main class.
     include_once('acf-recaptcha-v5.php');
 }
 

--- a/acf-recaptcha.php
+++ b/acf-recaptcha.php
@@ -23,11 +23,13 @@ load_plugin_textdomain('acf-recaptcha', false, dirname(plugin_basename(__FILE__)
 
 /**
  * Loads the field type.
+ * Will only be called if the ACF plugin is active.
  */
 function include_field_types_recaptcha($version) {
     // Only support version 5.
     if ($version !== 5) {
-        add_action('admin_notices', 'acf_recaptcha_version_4_admin_notice');
+        add_action('admin_notices', 'acf_unsupported_admin_notice');
+        add_action('admin_notices', 'acf_unsupported_disable_plugin');
         return;
     }
 
@@ -47,10 +49,18 @@ add_action('acf/include_field_types', 'include_field_types_recaptcha');
 /**
  * Show admin notice if ACF version is not supported.
  */
-function acf_recaptcha_version_4_admin_notice() {
+function acf_unsupported_admin_notice() {
     $class = 'notice notice-error';
     $notice = __('NOTICE', 'acf-recaptcha');
-    $message = __('ACF reCAPTCHA is not supported on Advanced Custom Fields 4.', 'acf-recaptcha');
+    $message = __('ACF reCAPTCHA is only supported on Advanced Custom Fields 5. The plugin has been disabled.', 'acf-recaptcha');
 
     printf('<div class="%1$s"><p><strong>%2$s: </strong>%3$s</p></div>', esc_attr($class), $notice, esc_html($message));
+}
+
+
+/**
+ * Disables the plugin if ACF version is not supported.
+ */
+function acf_unsupported_disable_plugin() {
+    deactivate_plugins(ACF_RECAPTCHA_ABSPATH, true);
 }

--- a/acf-recaptcha.php
+++ b/acf-recaptcha.php
@@ -27,6 +27,7 @@ load_plugin_textdomain('acf-recaptcha', false, dirname(plugin_basename(__FILE__)
 function include_field_types_recaptcha($version) {
     // Only support version 5.
     if ($version !== 5) {
+        add_action('admin_notices', 'acf_recaptcha_version_4_admin_notice');
         return;
     }
 
@@ -42,3 +43,14 @@ function include_field_types_recaptcha($version) {
 
 add_action('acf/include_field_types', 'include_field_types_recaptcha');
 
+
+/**
+ * Show admin notice if ACF version is not supported.
+ */
+function acf_recaptcha_version_4_admin_notice() {
+    $class = 'notice notice-error';
+    $notice = __('NOTICE', 'acf-recaptcha');
+    $message = __('ACF reCAPTCHA is not supported on Advanced Custom Fields 4.', 'acf-recaptcha');
+
+    printf('<div class="%1$s"><p><strong>%2$s: </strong>%3$s</p></div>', esc_attr($class), $notice, esc_html($message));
+}


### PR DESCRIPTION
Prevents errors like #27 if the wrong version of ACF is installed.

To be fully tested once I'm back, in case this breaks something.